### PR TITLE
v2.1.0 - Work Queues and the Kademlia Keyspace

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ addons:
       - g++-4.8
       - clang
 node_js:
-  - "4.4.3"
+  - "6.9.1"
 before_install:
   - export CXX="g++-4.8" CC="gcc-4.8"
 after_script:

--- a/lib/config.js
+++ b/lib/config.js
@@ -37,7 +37,7 @@ function BaseConfig(config) {
  * Returns an plain object
  */
 BaseConfig.prototype.toObject = function() {
-  return Object.create(this._);
+  return JSON.parse(JSON.stringify(this._));
 };
 
 /**
@@ -69,6 +69,8 @@ function RenterConfig(options) {
 
   this._.networkPrivateExtendedKey = options.networkPrivateExtendedKey;
   this._.networkIndex = options.networkIndex;
+  this._.totalRenters = options.totalRenters || 1;
+  this._.renterOverlap = options.renterOverlap || 1;
   this._.migrationPrivateKey = options.migrationPrivateKey || null;
   this._.networkOpts = options.networkOpts;
   this._.mongoUrl = options.mongoUrl;

--- a/lib/config.js
+++ b/lib/config.js
@@ -54,6 +54,7 @@ BaseConfig.prototype.toObject = function() {
  * @param {Object} options.networkOpts - Options to pass to RenterInterface
  */
 function RenterConfig(options) {
+  /* jshint maxstatements:false */
   if (!(this instanceof RenterConfig)) {
     return new RenterConfig(options);
   }

--- a/lib/landlord.js
+++ b/lib/landlord.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var crypto = require('crypto');
 var restify = require('restify');
 var storj = require('storj-lib');
 var ReadableStream = require('readable-stream');
@@ -35,6 +36,7 @@ function Landlord(options) {
     name: 'Storj Complex'
   }, this._opts.serverOpts));
 
+  this._workerSockets = {};
   this._bindServerRoutes();
   ReadableStream.call(this);
   this._logger.on('data', this.push.bind(this));
@@ -109,19 +111,40 @@ Landlord.prototype._initMessageBus = function() {
   this._logger.info('initializing message bus');
 
   // Setup our amqp sockets
-  this.publisher = this._amqpContext.socket('PUBLISH');
   this.subscriber = this._amqpContext.socket('SUBSCRIBE');
-  this.pusher = this._amqpContext.socket('PUSH');
 
   // Connect to our renter minion and listen for finished work
-  this.publisher.connect('pool');
   this.subscriber.connect('work.close');
-  this.pusher.connect('work.open');
+  this._establishWorkSockets();
 
   // Set up handlers for receiving work
   // Set up handlers for renter alerts
   this.subscriber.on('data', this._handleWorkResult.bind(this));
   this.emit('ready');
+};
+
+/**
+ * Returns the worker socket for the given key
+ * @param {String} key
+ */
+Landlord.prototype.getWorkerSocketForKey = function(key) {
+  var byteValue = Buffer(key, 'hex')[0];
+  var exchangeName = 'work-x-' + Buffer([byteValue]).toString('hex');
+  return this._workerSockets[exchangeName];
+};
+
+/**
+ * Establishes sockets for each possible first bit of renter node id
+ * @private
+ */
+Landlord.prototype._establishWorkSockets = function() {
+  for (let b = 0; b < 256; b++) {
+    let name = 'work-x-' + Buffer([b]).toString('hex');
+    let sock = this._workerSockets[name] = this._amqpContext.socket('PUSH');
+    sock.connect(name);
+  }
+
+  return this._workerSockets;
 };
 
 /**
@@ -181,9 +204,14 @@ Landlord.prototype._setJsonRpcRequestTimeout = function(req) {
  */
 Landlord.prototype._handleJsonRpcRequest = function(req, res) {
   var error = this._checkJsonRpcRequest(req);
+
   if (error) {
-    res.send(error);
+    return res.send(error);
   }
+
+  // Determine which exchange to publish work to
+  var key = this._getKeyFromRpcMessage(req.body);
+  var exchange = this.getWorkerSocketForKey(key);
 
   // Keep track of the response object for later
   this._pendingResponses[req.body.id] = res;
@@ -191,9 +219,26 @@ Landlord.prototype._handleJsonRpcRequest = function(req, res) {
   // Add work to the renter pool
   this._logger.info('writing to worker pool');
   this._logger.debug('rpc: %j', req.body);
-  this.pusher.write(new Buffer(JSON.stringify(req.body)));
-
   this._setJsonRpcRequestTimeout(req);
+
+  exchange.write(new Buffer(JSON.stringify(req.body)));
+};
+
+/**
+ * Extracts the key from the RPC request payload
+ * @private
+ */
+Landlord.prototype._getKeyFromRpcMessage = function(rpc) {
+  switch (rpc.method) {
+    case 'getConsignmentPointer':
+    case 'getRetrievalPointer':
+    case 'getStorageProof':
+      return rpc.params[0].nodeID; // Key based on the target farmer
+    case 'getStorageOffer':
+      return rpc.params[0].data_hash; // Key based on the data hash
+    default:
+      return crypto.randomBytes(1).toString('hex'); // Select a random exchange
+  }
 };
 
 /**

--- a/lib/renter.js
+++ b/lib/renter.js
@@ -207,17 +207,21 @@ Renter.prototype._loadKnownSeeds = function(callback) {
 Renter.prototype._initMessageBus = function() {
   /* jshint maxstatements:false */
   var self = this;
+  var exchangeByteStart = Buffer(this.network.contact.nodeID, 'hex')[0] - 4;
+  var exchangeByteEnd = exchangeByteStart + 8;
+
+  this.workers = {};
+
+  for (let b = exchangeByteStart; b <= exchangeByteEnd; b++) {
+    let name = 'work-x-' + Buffer([b]).toString('hex');
+    let sock = this.workers[name] = this._amqpContext.socket('WORKER');
+    sock.connect(name);
+    sock.on('data', this._handleWork.bind(this));
+  }
 
   // Setup our amqp sockets
   this.notifier = this._amqpContext.socket('PUBLISH');
-  this.worker = this._amqpContext.socket('WORKER');
-
-  // Connect to our renter friends and our landlord
   this.notifier.connect('work.close');
-  this.worker.connect('work.open');
-
-  // Set up handlers for receiving work
-  this.worker.on('data', this._handleWork.bind(this));
 
   // Join the network!
   this.network.join(function(err) {

--- a/lib/renter.js
+++ b/lib/renter.js
@@ -26,6 +26,8 @@ var Storage = require('storj-service-storage-models');
  * @param {String} options.amqpUrl - The URL for the RabbitMQ server
  * @param {Object} options.amqpOpts - Options to pass the RabbitMQ context
  * @param {Number} options.logLevel - The verbosity level for logging
+ * @param {Number} options.totalRenters - The total number of renter in pool
+ * @param {Number} options.renterOverlap - Desired queue subscription overlap
  */
 function Renter(options) {
   if (!(this instanceof Renter)) {
@@ -201,14 +203,25 @@ Renter.prototype._loadKnownSeeds = function(callback) {
 };
 
 /**
+ * Calculate the offset of queues
+ * @private
+ */
+Renter.prototype._getQueueOffset = function() {
+  return Math.ceil(
+    256 / this._opts.totalRenters * this._opts.renterOverlap / 2
+  );
+};
+
+/**
  * Initialize the rabbitmq message bus
  * @private
  */
 Renter.prototype._initMessageBus = function() {
   /* jshint maxstatements:false */
   var self = this;
-  var exchangeByteStart = Buffer(this.network.contact.nodeID, 'hex')[0] - 4;
-  var exchangeByteEnd = exchangeByteStart + 8;
+  var offset = this._getQueueOffset();
+  var exchangeByteStart = Buffer(this.network.contact.nodeID, 'hex')[0] - offset;
+  var exchangeByteEnd = exchangeByteStart + (offset * 2);
 
   this.workers = {};
 

--- a/lib/renter.js
+++ b/lib/renter.js
@@ -220,7 +220,8 @@ Renter.prototype._initMessageBus = function() {
   /* jshint maxstatements:false */
   var self = this;
   var offset = this._getQueueOffset();
-  var exchangeByteStart = Buffer(this.network.contact.nodeID, 'hex')[0] - offset;
+  var nodeId = this.network.contact.nodeID;
+  var exchangeByteStart = Buffer(nodeId, 'hex')[0] - offset;
   var exchangeByteEnd = exchangeByteStart + (offset * 2);
 
   this.workers = {};
@@ -229,7 +230,7 @@ Renter.prototype._initMessageBus = function() {
     let name = 'work-x-' + Buffer([b]).toString('hex');
     let sock = this.workers[name] = this._amqpContext.socket('WORKER');
     sock.connect(name);
-    sock.on('data', this._handleWork.bind(this, name));
+    sock.on('data', this._handleWork.bind(this, sock));
   }
 
   // Setup our amqp sockets
@@ -270,12 +271,12 @@ Renter.prototype._handleNetworkEvents = function() {
  * Handles work received from a landlord
  * @private
  */
-Renter.prototype._handleWork = function(name, buffer) {
+Renter.prototype._handleWork = function(sock, buffer) {
   var self = this;
   var data = JSON.parse(buffer.toString());
 
   // Acknowledge we have received the work
-  this.workers[name].ack();
+  sock.ack();
   this._logger.info('received job %s', data.id);
 
   if (Renter.SAFE_LANDLORD_METHODS.indexOf(data.method) === -1) {
@@ -301,7 +302,6 @@ Renter.prototype._handleWork = function(name, buffer) {
     }
 
     var argsArray = Array.prototype.slice.call(arguments);
-
     var args = self._serializeArguments(data.method, argsArray);
 
     self.notifier.write(new Buffer(JSON.stringify({

--- a/lib/renter.js
+++ b/lib/renter.js
@@ -229,7 +229,7 @@ Renter.prototype._initMessageBus = function() {
     let name = 'work-x-' + Buffer([b]).toString('hex');
     let sock = this.workers[name] = this._amqpContext.socket('WORKER');
     sock.connect(name);
-    sock.on('data', this._handleWork.bind(this));
+    sock.on('data', this._handleWork.bind(this, name));
   }
 
   // Setup our amqp sockets
@@ -270,12 +270,12 @@ Renter.prototype._handleNetworkEvents = function() {
  * Handles work received from a landlord
  * @private
  */
-Renter.prototype._handleWork = function(buffer) {
+Renter.prototype._handleWork = function(name, buffer) {
   var self = this;
   var data = JSON.parse(buffer.toString());
 
   // Acknowledge we have received the work
-  this.worker.ack();
+  this.workers[name].ack();
   this._logger.info('received job %s', data.id);
 
   if (Renter.SAFE_LANDLORD_METHODS.indexOf(data.method) === -1) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "storj-complex",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "manage many storj renter nodes with remote control capabilities",
   "main": "index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "request": "^2.75.0",
     "restify": "^4.1.1",
     "secp256k1": "^3.2.2",
-    "storj-lib": "^5.0.0",
+    "storj-lib": "^5.1.2",
     "storj-mongodb-adapter": "^4.0.1",
     "storj-service-storage-models": "^5.0.2"
   },

--- a/test/client.unit.js
+++ b/test/client.unit.js
@@ -322,9 +322,10 @@ describe('Client', function() {
       ];
       var result = client._serializeRequestArguments(method, args);
       expect(result[0].lastSeen).to.be.a('number');
+      expect(result[0].userAgent).to.be.a('string');
       delete result[0].lastSeen;
+      delete result[0].userAgent;
       expect(JSON.parse(JSON.stringify(result[0]))).to.deep.equal({
-        userAgent: '5.1.2',
         protocol: '0.10.0',
         address: '127.0.0.1',
         port: 3030,
@@ -367,9 +368,10 @@ describe('Client', function() {
       ];
       var result = client._serializeRequestArguments(method, args);
       expect(result[0].lastSeen).to.be.a('number');
+      expect(result[0].userAgent).to.be.a('string');
       delete result[0].lastSeen;
+      delete result[0].userAgent;
       expect(JSON.parse(JSON.stringify(result[0]))).to.deep.equal({
-        userAgent: '5.1.2',
         protocol: '0.10.0',
         address: '127.0.0.1',
         port: 3030,

--- a/test/client.unit.js
+++ b/test/client.unit.js
@@ -324,7 +324,7 @@ describe('Client', function() {
       expect(result[0].lastSeen).to.be.a('number');
       delete result[0].lastSeen;
       expect(JSON.parse(JSON.stringify(result[0]))).to.deep.equal({
-        userAgent: '5.1.0',
+        userAgent: '5.1.2',
         protocol: '0.10.0',
         address: '127.0.0.1',
         port: 3030,
@@ -369,7 +369,7 @@ describe('Client', function() {
       expect(result[0].lastSeen).to.be.a('number');
       delete result[0].lastSeen;
       expect(JSON.parse(JSON.stringify(result[0]))).to.deep.equal({
-        userAgent: '5.1.0',
+        userAgent: '5.1.2',
         protocol: '0.10.0',
         address: '127.0.0.1',
         port: 3030,

--- a/test/client.unit.js
+++ b/test/client.unit.js
@@ -1,5 +1,7 @@
 'use strict';
 
+/* jshint maxstatements:false */
+
 var storj = require('storj-lib');
 var request = require('request');
 var sinon = require('sinon');

--- a/test/renter.unit.js
+++ b/test/renter.unit.js
@@ -319,7 +319,9 @@ describe('Renter', function() {
     });
     var options = {
       networkPrivateExtendedKey: hdKey.privateExtendedKey,
-      networkIndex: 10
+      networkIndex: 10,
+      totalRenters: 32,
+      renterOverlap: 1
     };
     it('setup sockets, connect, join network and handle work', function() {
       sandbox.stub(Renter.prototype, '_handleWork');
@@ -527,7 +529,9 @@ describe('Renter', function() {
       var parsed = JSON.parse(write.args[0][0].toString());
       // remove last seen property that changes
       expect(parsed.result[1].farmer.lastSeen).to.be.a('number');
+      expect(parsed.result[1].farmer.userAgent).to.be.a('string');
       delete parsed.result[1].farmer.lastSeen;
+      delete parsed.result[1].farmer.userAgent;
       expect(parsed).to.deep.equal({
         id: 'someid',
         result: [
@@ -537,8 +541,7 @@ describe('Renter', function() {
               address: '127.0.0.1',
               nodeID: '955af05f3130ac5c70952a34a9aa710c9fbf812b',
               port: 3000,
-              protocol: '0.10.0',
-              userAgent: '5.1.2'
+              protocol: '0.10.0'
             },
             hash: 'fad8d3a30b5d40dae9e61f7f84bf9017e9f4bb2f',
             operation: 'PULL',

--- a/test/renter.unit.js
+++ b/test/renter.unit.js
@@ -538,7 +538,7 @@ describe('Renter', function() {
               nodeID: '955af05f3130ac5c70952a34a9aa710c9fbf812b',
               port: 3000,
               protocol: '0.10.0',
-              userAgent: '5.1.0'
+              userAgent: '5.1.2'
             },
             hash: 'fad8d3a30b5d40dae9e61f7f84bf9017e9f4bb2f',
             operation: 'PULL',

--- a/test/renter.unit.js
+++ b/test/renter.unit.js
@@ -373,7 +373,8 @@ describe('Renter', function() {
       var data = {};
       renter.workers['work-x-47'].emit('data', data);
       expect(Renter.prototype._handleWork.callCount).to.equal(1);
-      expect(Renter.prototype._handleWork.args[0][0]).to.equal(data);
+      expect(Renter.prototype._handleWork.args[0][0]).to.equal('work-x-47');
+      expect(Renter.prototype._handleWork.args[0][1]).to.equal(data);
       expect(renter._handleNetworkEvents.callCount).to.equal(1);
     });
     it('will emit error from network join', function(done) {
@@ -469,8 +470,8 @@ describe('Renter', function() {
 
     it('will give method not found message', function() {
       var renter = complex.createRenter(options);
-      renter.worker = {
-        ack: sinon.stub()
+      renter.workers = {
+        test: { ack: sinon.stub() }
       };
       var write = sinon.stub();
       renter.notifier = {
@@ -480,7 +481,7 @@ describe('Renter', function() {
         method: 'someUnknownMethod',
         id: 'someid'
       }));
-      renter._handleWork(buffer);
+      renter._handleWork('test', buffer);
       expect(write.callCount).to.equal(1);
       expect(JSON.parse(write.args[0][0].toString())).to.deep.equal({
         id: 'someid',
@@ -489,7 +490,7 @@ describe('Renter', function() {
           message: 'Method not found'
         }
       });
-      expect(renter.worker.ack.callCount).to.equal(1);
+      expect(renter.workers.test.ack.callCount).to.equal(1);
     });
 
     it('will serialize/deserialize args with redirected method', function() {
@@ -504,8 +505,8 @@ describe('Renter', function() {
         'PULL'
       );
       renter._getRetrievalPointer = sinon.stub().callsArgWith(2, null, pointer);
-      renter.worker = {
-        ack: sinon.stub()
+      renter.workers = {
+        test: { ack: sinon.stub() }
       };
       var write = sinon.stub();
       renter.notifier = {
@@ -524,7 +525,7 @@ describe('Renter', function() {
           }
         ]
       }));
-      renter._handleWork(buffer);
+      renter._handleWork('test', buffer);
       expect(write.callCount).to.equal(1);
       var parsed = JSON.parse(write.args[0][0].toString());
       // remove last seen property that changes
@@ -549,7 +550,7 @@ describe('Renter', function() {
           }
         ]
       });
-      expect(renter.worker.ack.callCount).to.equal(1);
+      expect(renter.workers.test.ack.callCount).to.equal(1);
     });
 
     it('will serialize/deserialize args for non-redirect', function() {
@@ -569,8 +570,8 @@ describe('Renter', function() {
         '07a925e3bb75cfc5e00e15207e4a90ee6c897513'
       ];
       var renter = complex.createRenter(options);
-      renter.worker = {
-        ack: sinon.stub()
+      renter.workers = {
+        test: { ack: sinon.stub() }
       };
       renter.network = {
         getStorageProof: sinon.stub().callsArgWith(2, null, proof)
@@ -589,20 +590,20 @@ describe('Renter', function() {
         id: 'someid',
         params: [ farmer, item ]
       }));
-      renter._handleWork(buffer);
+      renter._handleWork('test', buffer);
       expect(write.callCount).to.equal(1);
       var parsed = JSON.parse(write.args[0][0].toString());
       expect(parsed).to.deep.equal({
         id: 'someid',
         result: [ null, proof ]
       });
-      expect(renter.worker.ack.callCount).to.equal(1);
+      expect(renter.workers.test.ack.callCount).to.equal(1);
     });
 
     it('will give error from calling method', function() {
       var renter = complex.createRenter(options);
-      renter.worker = {
-        ack: sinon.stub()
+      renter.workers = {
+        test: { ack: sinon.stub() }
       };
       renter.network = {
         getStorageProof: sinon.stub().callsArgWith(2, new Error('test'))
@@ -621,7 +622,7 @@ describe('Renter', function() {
         id: 'someid',
         params: [ farmer, item ]
       }));
-      renter._handleWork(buffer);
+      renter._handleWork('test', buffer);
       expect(write.callCount).to.equal(1);
       var parsed = JSON.parse(write.args[0][0].toString());
       expect(parsed).to.deep.equal({
@@ -631,13 +632,13 @@ describe('Renter', function() {
           message: 'test'
         }
       });
-      expect(renter.worker.ack.callCount).to.equal(1);
+      expect(renter.workers.test.ack.callCount).to.equal(1);
     });
 
     it('will give error if calling method', function() {
       var renter = complex.createRenter(options);
-      renter.worker = {
-        ack: sinon.stub()
+      renter.workers = {
+        test: { ack: sinon.stub() }
       };
       renter.network = {
         getStorageProof: sinon.stub().throws(new Error('test'))
@@ -656,7 +657,7 @@ describe('Renter', function() {
         id: 'someid',
         params: [ farmer, item ]
       }));
-      renter._handleWork(buffer);
+      renter._handleWork('test', buffer);
       expect(write.callCount).to.equal(1);
       var parsed = JSON.parse(write.args[0][0].toString());
       expect(parsed).to.deep.equal({
@@ -666,7 +667,7 @@ describe('Renter', function() {
           message: 'test'
         }
       });
-      expect(renter.worker.ack.callCount).to.equal(1);
+      expect(renter.workers.test.ack.callCount).to.equal(1);
     });
 
   });

--- a/test/renter.unit.js
+++ b/test/renter.unit.js
@@ -373,7 +373,9 @@ describe('Renter', function() {
       var data = {};
       renter.workers['work-x-47'].emit('data', data);
       expect(Renter.prototype._handleWork.callCount).to.equal(1);
-      expect(Renter.prototype._handleWork.args[0][0]).to.equal('work-x-47');
+      expect(Renter.prototype._handleWork.args[0][0]).to.be.instanceOf(
+        EventEmitter
+      );
       expect(Renter.prototype._handleWork.args[0][1]).to.equal(data);
       expect(renter._handleNetworkEvents.callCount).to.equal(1);
     });
@@ -481,7 +483,7 @@ describe('Renter', function() {
         method: 'someUnknownMethod',
         id: 'someid'
       }));
-      renter._handleWork('test', buffer);
+      renter._handleWork(renter.workers.test, buffer);
       expect(write.callCount).to.equal(1);
       expect(JSON.parse(write.args[0][0].toString())).to.deep.equal({
         id: 'someid',
@@ -525,7 +527,7 @@ describe('Renter', function() {
           }
         ]
       }));
-      renter._handleWork('test', buffer);
+      renter._handleWork(renter.workers.test, buffer);
       expect(write.callCount).to.equal(1);
       var parsed = JSON.parse(write.args[0][0].toString());
       // remove last seen property that changes
@@ -590,7 +592,7 @@ describe('Renter', function() {
         id: 'someid',
         params: [ farmer, item ]
       }));
-      renter._handleWork('test', buffer);
+      renter._handleWork(renter.workers.test, buffer);
       expect(write.callCount).to.equal(1);
       var parsed = JSON.parse(write.args[0][0].toString());
       expect(parsed).to.deep.equal({
@@ -622,7 +624,7 @@ describe('Renter', function() {
         id: 'someid',
         params: [ farmer, item ]
       }));
-      renter._handleWork('test', buffer);
+      renter._handleWork(renter.workers.test, buffer);
       expect(write.callCount).to.equal(1);
       var parsed = JSON.parse(write.args[0][0].toString());
       expect(parsed).to.deep.equal({
@@ -657,7 +659,7 @@ describe('Renter', function() {
         id: 'someid',
         params: [ farmer, item ]
       }));
-      renter._handleWork('test', buffer);
+      renter._handleWork(renter.workers.test, buffer);
       expect(write.callCount).to.equal(1);
       var parsed = JSON.parse(write.args[0][0].toString());
       expect(parsed).to.deep.equal({


### PR DESCRIPTION
### Problem

Currently, the bridge issues work to complex via RPC messages to a `Landlord`. The `Landord`, in turn, publishes the RPC message as a job to a single work exchange queue to which all `Renter`s are connected. The selection of the `Renter` is a simple round-robin, which is prone to issues for the following reasons:

* Work in Storj is almost always tied to the keyspace. For instance, retrieving a token from a farmer with a Node ID of `abcxxx...` may not complete if the job is given to a renter with a Node ID of `xyzxxx...` due to the XOR distance between the two parties and the resulting required iterations to locate the target.
* Publishing a storage contract is supposed to enter the network closest to the shard's hash, but if the publishing renter is itself very distant from that hash, it's pool of known contacts close to the hash will be much smaller than a close node, which can result in fewer offers and lead to problems with establishing mirrors later on.
* Retrieval of transfer tokens becomes non-deterministic. Two consecutive `getRetrievalPointer` RPCs may yield different results depending on the renter who was selected for the work. If a distant node receives the work, the likelihood that it will fail is higher. A second try may select a closer node, which has a higher likelihood to succeed.

### Solution

Taking some lessons from KFS, we can separate exchanges into different sectors of the key space. We create 256 distinct work exchange queues: each one for a possible first byte value of a renter's Node ID, prefixed with `work-x-*`. Each renter, instead of subscribing to a single work exchange will subscribe to 9 exchanges: one for their exact first byte value and the 4 preceding and following it.

For example, a renter with the node ID `4b783710baab517de2e3de5bae7e749c9d0e5170`, will subscribe to the following queues:

+ `work-x-47`
+ `work-x-48`
+ `work-x-49`
+ `work-x-4a`
+ `work-x-4b`
+ `work-x-4c`
+ `work-x-4d`
+ `work-x-4e`
+ `work-x-4f`

When a `Landlord` needs to publish work to an exchange, it will determine which is appropriate by inspecting the RPC message for information about where in the network's keyspace the work is ultimately destined to be carried out and take the first byte of either the target farmer's Node ID or the hash of the shard to be published and select that exchange. For example for a shard hash of `47be7c6a52c0451b06a829df7da2775e78a4adf7`, the work would be published to the `work-x-47` exchange.

This means that only renters with a Node ID that has a leading byte (as hex) between `43` and `4b` will be selected for the job, which in the previous example would be covered by our renter with Node ID `4b783710baab517de2e3de5bae7e749c9d0e5170`. This will allow complex to better optimize renter selection for appropriate work.

### Considerations

* Since producers and consumers in RabbitMQ have no knowledge of each other, we must rely on a minimum volume of renters in the pool to avoid "dead" areas in the key space. Technically there could be as few as 32 renters to cover all 256 exchanges, but since Node ID generation is random, it's possible that there will be overlap. Setting a higher minimum number of renters like 64 or even 128 can resolve this until a method for detecting gaps in coverage is devised.

---

This PR implements the system described above and includes updated tests where relevant. 

* Closes storj/core#553
* Closes #21 