### PR TITLE
Record lastTimeout on contact

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -96,12 +96,16 @@ function LandlordConfig(options) {
   }
 
   BaseConfig.call(this, options);
+  assert(typeof options.mongoUrl === 'string', 'Invalid mongoUrl');
+  assert(typeof options.mongoOpts === 'object', 'Invalid mongoOpts');
   assert(typeof options.serverPort === 'number', 'Invalid serverPort');
   assert(typeof options.serverOpts === 'object', 'Invalid serverOpts');
 
   this._.serverPort = options.serverPort;
   this._.serverOpts = options.serverOpts;
   this._.serverOpts.authorization = options.serverOpts.authorization || {};
+  this._.mongoUrl = options.mongoUrl;
+  this._.mongoOpts = options.mongoOpts;
 }
 
 inherits(LandlordConfig, BaseConfig);

--- a/lib/landlord.js
+++ b/lib/landlord.js
@@ -7,6 +7,7 @@ var ReadableStream = require('readable-stream');
 var inherits = require('util').inherits;
 var rabbitmq = require('rabbit.js');
 var Logger = require('kad-logger-json');
+var Storage = require('storj-service-storage-models');
 var merge = require('merge');
 var assert = require('assert');
 var LandlordConfig = require('./config').LandlordConfig;
@@ -49,6 +50,20 @@ inherits(Landlord, ReadableStream);
 Landlord.REQUEST_TIMEOUT = 90000;
 
 /**
+ * Initializes storage instance
+ * @private
+ */
+Landlord.prototype._initStorage = function() {
+  this.storage = new Storage(
+    this._opts.mongoUrl,
+    this._opts.mongoOpts,
+    {
+      logger: this._logger
+    }
+  );
+};
+
+/**
  * @private
  */
 Landlord.prototype._read = storj.utils.noop;
@@ -70,6 +85,9 @@ Landlord.prototype._bindServerRoutes = function() {
  */
 Landlord.prototype.start = function(callback) {
   var self = this;
+
+  // Set up our database connection for shared contract storage
+  this._initStorage();
 
   // Start our RPC server
   this._logger.info('starting rpc server on port %s', this._opts.serverPort);
@@ -194,6 +212,36 @@ Landlord.prototype._logRequestTimeout = function(rpc) {
   this._logger.warn('job timed out, method: %s, id: %s, ' +
                     'data_hash: %s, node_id: %s',
                     rpc.method, rpc.id, dataHash, nodeID);
+
+  if (nodeID) {
+    this._recordRequestTimeout(nodeID);
+  }
+
+};
+
+Landlord.prototype._recordRequestTimeout = function(nodeID) {
+  this.storage.models.Contact.findOne({_id: nodeID}, (err, contact) => {
+    if (err) {
+      this._logger.warn('recordRequestTimeout: Error trying to find contact ' +
+                        ' %s, reason: %s', nodeID, err.message);
+      return;
+    }
+
+    if (!contact) {
+      this._logger.warn('recordRequestTimeout: Unable to find contact %s',
+                        nodeID);
+      return;
+    }
+
+    contact.lastTimeout = Date.now();
+
+    contact.save((err) => {
+      if (err) {
+        this._logger.warn('recordRequestTimeout: Unable to save contact %s ' +
+                          'to update lastTimeout.', nodeID);
+      }
+    });
+  });
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "secp256k1": "^3.2.2",
     "storj-lib": "^6.0.7",
     "storj-mongodb-adapter": "^5.0.0",
-    "storj-service-storage-models": "^6.0.0",
+    "storj-service-storage-models": "^6.0.1",
     "uuid": "^3.0.0"
   },
   "devDependencies": {

--- a/test/config.unit.js
+++ b/test/config.unit.js
@@ -43,6 +43,8 @@ describe('Base Config', function() {
           logLevel: 3,
           amqpUrl: 'amqp://localhost',
           amqpOpts: {},
+          mongoUrl: 'mongodb://localhost:27017/storj-test',
+          mongoOpts: {},
           serverPort: 8080,
           serverOpts: {
             certificate: null,
@@ -229,7 +231,9 @@ describe('Landlord Config', function() {
       amqpUrl: 'amqp://localhost',
       amqpOpts: {},
       serverPort: 3030,
-      serverOpts: {}
+      serverOpts: {},
+      mongoUrl: 'mongodb://localhost:27017/storj-test',
+      mongoOpts: {},
     };
     var config = new LandlordConfig(opts);
     expect(config).to.be.instanceOf(LandlordConfig);
@@ -244,6 +248,8 @@ describe('Landlord Config', function() {
         logLevel: 3,
         amqpUrl: 'amqp://localhost',
         amqpOpts: {},
+        mongoUrl: 'mongodb://localhost:27017/storj-test',
+        mongoOpts: {},
         serverPort: 8080,
         serverOpts: {
           certificate: '/tmp/certificate.pem',
@@ -263,6 +269,8 @@ describe('Landlord Config', function() {
     var conf = complex.createConfig('/tmp/somepath.json');
     expect(conf._.serverOpts.certificate).to.equal('pem');
     expect(conf._.serverOpts.key).to.equal('pem');
+    expect(conf._.mongoUrl).to.equal('mongodb://localhost:27017/storj-test');
+    expect(conf._.mongoOpts).to.eql({});
   });
 
 });


### PR DESCRIPTION
- Adds config options to Landlord for `mongoUrl` and `mongoOpts`
- Records the `lastTimeout` for a contact, so that https://github.com/Storj/bridge/pull/303 can use the value to filter getting pointers from the contact.