### PR TITLE
Keep track of response times for contacts

### DIFF
--- a/lib/landlord.js
+++ b/lib/landlord.js
@@ -31,7 +31,8 @@ function Landlord(options) {
                options.toObject() :
                options;
   this._logger = new Logger(this._opts.logLevel);
-  this._pendingResponses = {};
+
+  this._pendingJobs = {};
 
   this.server = restify.createServer(merge({
     name: 'Storj Complex'
@@ -234,6 +235,7 @@ Landlord.prototype._recordRequestTimeout = function(nodeID) {
     }
 
     contact.lastTimeout = Date.now();
+    contact.recordResponseTime(this._requestTimeout);
 
     contact.save((err) => {
       if (err) {
@@ -254,17 +256,18 @@ Landlord.prototype._setJsonRpcRequestTimeout = function(req) {
 
   // If work isn't completed in time, respond with an error
   setTimeout(function() {
-    if (!self._pendingResponses[req.body.id]) {
+    if (!self._pendingJobs[req.body.id]) {
       return;
     }
 
     self._logRequestTimeout(req.body);
 
-    self._pendingResponses[req.body.id].send(
+    self._pendingJobs[req.body.id].res.send(
       new restify.errors.RequestTimeoutError()
     );
 
-    delete self._pendingResponses[req.body.id];
+    delete self._pendingJobs[req.body.id];
+
   }, self._requestTimeout);
 };
 
@@ -283,8 +286,12 @@ Landlord.prototype._handleJsonRpcRequest = function(req, res) {
   var key = this._getKeyFromRpcMessage(req.body);
   var exchange = this.getWorkerSocketForKey(key);
 
-  // Keep track of the response object for later
-  this._pendingResponses[req.body.id] = res;
+  // Keep track of the request/response object for later
+  this._pendingJobs[req.body.id] = {
+    req: req,
+    res: res,
+    start: Date.now()
+  };
 
   // Add work to the renter pool
   this._logger.info('writing to worker pool');
@@ -328,6 +335,59 @@ Landlord.prototype._isValidJsonRpcRequest = function(body) {
 };
 
 /**
+ * Updates the exponential moving average response time
+ * for the farmer.
+ * @private
+ */
+Landlord.prototype._recordSuccessTime = function(job) {
+  const rpc = job.req.body;
+  const responseTime = Date.now() - job.start;
+
+  if (!Number.isFinite(responseTime)) {
+    this._logger.warn('recordSuccesstime: responseTime is not finite %s',
+                      responseTime);
+    return;
+  }
+
+  let nodeID;
+
+  switch (rpc.method) {
+    case 'getConsignmentPointer':
+    case 'getRetrievalPointer':
+    case 'getStorageProof':
+      nodeID = rpc.params[0].nodeID;
+      break;
+  }
+
+  if (!nodeID) {
+    // No need to record time
+    return;
+  }
+
+  this.storage.models.Contact.findOne({_id: nodeID}, (err, contact) => {
+    if (err) {
+      this._logger.warn('recordSuccesstime: Error trying to find contact ' +
+                        ' %s, reason: %s', nodeID, err.message);
+      return;
+    }
+
+    if (!contact) {
+      this._logger.warn('recordSuccesstime: Unable to find contact %s',
+                        nodeID);
+      return;
+    }
+
+    contact.recordResponseTime(responseTime).save((err) => {
+      if (err) {
+        this._logger.warn('recordSuccessTime: Unable to save contact %s ' +
+                          'to update responseTime.', nodeID);
+      }
+    });
+
+  });
+};
+
+/**
  * Handle the result of some work completed
  * @private
  */
@@ -336,7 +396,7 @@ Landlord.prototype._handleWorkResult = function(buffer) {
   var data = JSON.parse(buffer.toString());
 
   // If this response already timed out do nothing
-  if (!self._pendingResponses[data.id]) {
+  if (!self._pendingJobs[data.id]) {
     return this._logger.warn('job %s completed late', data.id);
   }
 
@@ -344,7 +404,7 @@ Landlord.prototype._handleWorkResult = function(buffer) {
   if (data.error) {
     self._logger.warn('error returned from work result on job %s', data.id);
     self._logger.debug('error result: %j', data);
-    return self._pendingResponses[data.id].send(
+    return self._pendingJobs[data.id].res.send(
       new restify.errors.InternalServerError(data.error.message)
     );
   }
@@ -352,8 +412,12 @@ Landlord.prototype._handleWorkResult = function(buffer) {
   // Otherwise forward the result and delete the reference
   self._logger.info('job %s completed successfully', data.id);
   self._logger.debug('job result: %j', data);
-  self._pendingResponses[data.id].send(data);
-  delete self._pendingResponses[data.id];
+  self._pendingJobs[data.id].res.send(data);
+
+  // Keep track of response times
+  self._recordSuccessTime(self._pendingJobs[data.id]);
+
+  delete self._pendingJobs[data.id];
 };
 
 module.exports = Landlord;

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "secp256k1": "^3.2.2",
     "storj-lib": "^6.0.7",
     "storj-mongodb-adapter": "^5.0.0",
-    "storj-service-storage-models": "^6.0.1",
+    "storj-service-storage-models": "braydonf/storj-service-storage-models",
     "uuid": "^3.0.0"
   },
   "devDependencies": {

--- a/test/landlord.unit.js
+++ b/test/landlord.unit.js
@@ -584,6 +584,31 @@ describe('Landlord', function() {
       expect(landlord._logger.warn.callCount).to.equal(1);
     });
 
+    it('will not log or save for not relevant methods', function() {
+      const landlord = complex.createLandlord({});
+      const job = {
+        req: {
+          body: {
+            method: 'getStorageOffer'
+          }
+        },
+        res: {},
+        start: 1481927872255
+      };
+      const findOne = sandbox.stub().callsArgWith(1, null, null);
+      sandbox.stub(landlord._logger, 'warn');
+      landlord.storage = {
+        models: {
+          Contact: {
+            findOne: findOne
+          }
+        }
+      };
+      landlord._recordSuccessTime(job);
+      expect(landlord._logger.warn.callCount).to.equal(0);
+      expect(findOne.callCount).to.equal(0);
+    });
+
     it('it will log error looking up contact', function() {
       const landlord = complex.createLandlord({});
       const job = {

--- a/test/landlord.unit.js
+++ b/test/landlord.unit.js
@@ -25,7 +25,7 @@ describe('Landlord', function() {
       expect(landlord.server);
       expect(landlord.server).to.be.instanceOf(require('restify/lib/server'));
       expect(landlord._logger).to.be.instanceOf(require('kad-logger-json'));
-      expect(landlord._pendingResponses).to.deep.equal({});
+      expect(landlord._pendingJobs).to.deep.equal({});
       expect(Landlord.prototype._bindServerRoutes.callCount).to.equal(1);
     }
 
@@ -354,8 +354,10 @@ describe('Landlord', function() {
       var landlord = complex.createLandlord({ requestTimeout: 1 });
       sandbox.stub();
       var send = sinon.stub();
-      landlord._pendingResponses.someid = {
-        send: send
+      landlord._pendingJobs.someid = {
+        res: {
+          send: send
+        }
       };
       sandbox.stub(landlord._logger, 'warn');
       var req = {
@@ -392,8 +394,10 @@ describe('Landlord', function() {
       var landlord = complex.createLandlord({ requestTimeout: 1 });
       sandbox.stub();
       var send = sinon.stub();
-      landlord._pendingResponses.someid = {
-        send: send
+      landlord._pendingJobs.someid = {
+        res: {
+          send: send
+        }
       };
       sandbox.stub(landlord._logger, 'warn');
       var req = {
@@ -424,8 +428,10 @@ describe('Landlord', function() {
     it('will send error after timeout ', function(done) {
       var landlord = complex.createLandlord({ requestTimeout: 1 });
       var send = sandbox.stub();
-      landlord._pendingResponses.someid = {
-        send: send
+      landlord._pendingJobs.someid = {
+        res: {
+          send: send
+        }
       };
       var req = {
         body: {
@@ -435,7 +441,7 @@ describe('Landlord', function() {
       landlord._setJsonRpcRequestTimeout(req);
       setTimeout(function() {
         expect(send.callCount).to.equal(1);
-        expect(landlord._pendingResponses.someid).to.equal(undefined);
+        expect(landlord._pendingJobs.someid).to.equal(undefined);
         done();
       }, 2);
     });
@@ -450,7 +456,7 @@ describe('Landlord', function() {
       landlord._setJsonRpcRequestTimeout(req);
       setTimeout(function() {
         expect(send.callCount).to.equal(0);
-        expect(landlord._pendingResponses.someid).to.equal(undefined);
+        expect(landlord._pendingJobs.someid).to.equal(undefined);
         done();
       }, 2);
     });
@@ -580,8 +586,10 @@ describe('Landlord', function() {
         debug: sandbox.stub()
       };
       var send = sandbox.stub();
-      landlord._pendingResponses.someid = {
-        send: send
+      landlord._pendingJobs.someid = {
+        res: {
+          send: send
+        }
       };
       landlord._handleWorkResult(buffer);
       expect(landlord._logger.warn.callCount).to.equal(1);
@@ -605,14 +613,16 @@ describe('Landlord', function() {
         debug: sandbox.stub()
       };
       var send = sandbox.stub();
-      landlord._pendingResponses.someid = {
-        send: send
+      landlord._pendingJobs.someid = {
+        res: {
+          send: send
+        }
       };
       landlord._handleWorkResult(buffer);
       expect(landlord._logger.info.callCount).to.equal(1);
       expect(landlord._logger.debug.callCount).to.equal(1);
       expect(send.callCount).to.equal(1);
-      expect(landlord._pendingResponses.someid).to.equal(undefined);
+      expect(landlord._pendingJobs.someid).to.equal(undefined);
       expect(send.callCount).to.equal(1);
       expect(send.args[0][0]).to.deep.equal({
         hello: 'world',


### PR DESCRIPTION
Keep track of the response times for each contact, to be used for selecting contracts offers, and improving download response times and success rates.

Depends: https://github.com/Storj/service-storage-models/pull/34

Todo:
- [ ] Update package.json with released version of storj-service-storage-models