### PR TITLE
Add ping command, and record timeoutRate

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -188,4 +188,13 @@ Client.prototype.getStorageProof = function(farmer, item, callback) {
   this._send('getStorageProof', [farmer, item], callback);
 };
 
+/**
+ *@see http://storj.github.io/core/Network.html
+ */
+Client.prototype.ping = function(contact, callback) {
+  assert(farmer instanceof storj.Contact, 'Invalid contact supplied');
+  this._send('ping', [contact], callback);
+};
+
+
 module.exports = Client;

--- a/lib/client.js
+++ b/lib/client.js
@@ -192,7 +192,7 @@ Client.prototype.getStorageProof = function(farmer, item, callback) {
  *@see http://storj.github.io/core/Network.html
  */
 Client.prototype.ping = function(contact, callback) {
-  assert(farmer instanceof storj.Contact, 'Invalid contact supplied');
+  assert(contact instanceof storj.Contact, 'Invalid contact supplied');
   this._send('ping', [contact], callback);
 };
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -89,6 +89,9 @@ inherits(RenterConfig, BaseConfig);
  * @param {Object} options.serverOpts
  * @param {String} options.serverOpts.certificate - PEM SSL certificate
  * @param {String} options.serverOpts.key - PEM SSL key
+ * @param {String} options.mongoUrl - A full mongodb url
+ * @param {String} options.mongoOpts - Additional mongodb options
+ * @param {String} options.timeoutRateThreshold
  */
 function LandlordConfig(options) {
   if (!(this instanceof LandlordConfig)) {
@@ -106,6 +109,9 @@ function LandlordConfig(options) {
   this._.serverOpts.authorization = options.serverOpts.authorization || {};
   this._.mongoUrl = options.mongoUrl;
   this._.mongoOpts = options.mongoOpts;
+
+  // For triggering replication, default: ~1 hour of downtime in 24 hours
+  this._.timeoutRateThreshold = options.timeoutRateThreshold || 0.04;
 }
 
 inherits(LandlordConfig, BaseConfig);

--- a/lib/config.js
+++ b/lib/config.js
@@ -111,6 +111,8 @@ function LandlordConfig(options) {
   this._.mongoOpts = options.mongoOpts;
 
   // For triggering replication, default: ~1 hour of downtime in 24 hours
+  // NB: We need to make sure this configuration value matches
+  // what is also set for the monitoring service.
   this._.timeoutRateThreshold = options.timeoutRateThreshold || 0.04;
 }
 

--- a/lib/landlord.js
+++ b/lib/landlord.js
@@ -30,6 +30,7 @@ function Landlord(options) {
   this._opts = options instanceof LandlordConfig ?
                options.toObject() :
                options;
+
   this._logger = new Logger(this._opts.logLevel);
 
   this._pendingJobs = {};
@@ -235,6 +236,14 @@ Landlord.prototype._recordRequestTimeout = function(nodeID) {
     }
 
     contact.recordTimeoutFailure();
+
+    assert(this._opts.timeoutRateThreshold, 'timeoutRateThreshold is expected');
+
+    if (contact.timeoutRate >= this._opts.timeoutRateThreshold) {
+      this._logger.warn('Shards need replication, farmer: %s, timeoutRate: %s',
+                        contact.nodeID, contact.timeoutRate);
+    }
+
     contact.recordResponseTime(this._requestTimeout);
 
     contact.save((err) => {

--- a/lib/landlord.js
+++ b/lib/landlord.js
@@ -234,7 +234,7 @@ Landlord.prototype._recordRequestTimeout = function(nodeID) {
       return;
     }
 
-    contact.lastTimeout = Date.now();
+    contact.recordTimeoutFailure();
     contact.recordResponseTime(this._requestTimeout);
 
     contact.save((err) => {

--- a/lib/renter.js
+++ b/lib/renter.js
@@ -57,7 +57,8 @@ Renter.SAFE_LANDLORD_METHODS = [
   'getRetrievalPointer',
   'getMirrorNodes',
   'getStorageOffer',
-  'getStorageProof'
+  'getStorageProof',
+  'ping'
 ];
 
 Renter.METHOD_MAP_REDIRECT = {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "request": "^2.75.0",
     "restify": "^4.1.1",
     "secp256k1": "^3.2.2",
-    "storj-lib": "^6.0.7",
+    "storj-lib": "^6.0.12",
     "storj-mongodb-adapter": "^5.0.0",
     "storj-service-storage-models": "^6.1.1",
     "uuid": "^3.0.0"

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "secp256k1": "^3.2.2",
     "storj-lib": "^6.0.12",
     "storj-mongodb-adapter": "^5.0.0",
-    "storj-service-storage-models": "^6.1.1",
+    "storj-service-storage-models": "^7.0.0",
     "uuid": "^3.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "restify": "^4.1.1",
     "secp256k1": "^3.2.2",
     "storj-lib": "^6.0.12",
-    "storj-mongodb-adapter": "^5.0.0",
+    "storj-mongodb-adapter": "^6.0.0",
     "storj-service-storage-models": "^7.0.0",
     "uuid": "^3.0.0"
   },

--- a/test/client.unit.js
+++ b/test/client.unit.js
@@ -531,4 +531,23 @@ describe('Client', function() {
     });
   });
 
+  describe('#ping', function() {
+    it('should call send with correct params', function(done) {
+      var client = complex.createClient();
+      client._send = sinon.stub().callsArg(2);
+      var farmer = storj.Contact({
+        address: '127.0.0.1',
+        port: 3030
+      });
+      client.ping(farmer, function() {
+        expect(client._send.callCount).to.equal(1);
+        expect(client._send.args[0][0]).to.equal('ping');
+        expect(client._send.args[0][1]).to.deep.equal([
+          farmer
+        ]);
+        done();
+      });
+    });
+  });
+
 });

--- a/test/landlord.unit.js
+++ b/test/landlord.unit.js
@@ -316,7 +316,8 @@ describe('Landlord', function() {
       const landlord = complex.createLandlord({});
       const contact = {
         save: sinon.stub().callsArgWith(0, new Error('test')),
-        recordResponseTime: sinon.stub()
+        recordResponseTime: sinon.stub(),
+        recordTimeoutFailure: sinon.stub()
       };
       const findOne = sinon.stub().callsArgWith(1, null, contact);
       landlord.storage = {
@@ -332,13 +333,15 @@ describe('Landlord', function() {
       expect(landlord._logger.warn.callCount).to.equal(1);
       expect(contact.recordResponseTime.callCount).to.equal(1);
       expect(contact.recordResponseTime.args[0][0]).to.equal(90000);
+      expect(contact.recordTimeoutFailure.callCount).to.equal(1);
     });
 
     it('will save contact with updated lastTimeout', function() {
       const landlord = complex.createLandlord({});
       const contact = {
         save: sinon.stub().callsArgWith(0, null),
-        recordResponseTime: sinon.stub()
+        recordResponseTime: sinon.stub(),
+        recordTimeoutFailure: sinon.stub()
       };
       const findOne = sinon.stub().callsArgWith(1, null, contact);
       landlord.storage = {
@@ -353,6 +356,7 @@ describe('Landlord', function() {
       expect(findOne.callCount).to.equal(1);
       expect(landlord._logger.warn.callCount).to.equal(0);
       expect(contact.recordResponseTime.callCount).to.equal(1);
+      expect(contact.recordTimeoutFailure.callCount).to.equal(1);
     });
   });
 

--- a/test/renter.unit.js
+++ b/test/renter.unit.js
@@ -590,6 +590,36 @@ describe('Renter', function() {
       expect(renter.workers.test.ack.callCount).to.equal(1);
     });
 
+    it('will handle ping command', function() {
+      var renter = complex.createRenter(options);
+      renter.workers = {
+        test: { ack: sinon.stub() }
+      };
+      var write = sinon.stub();
+      renter.notifier = {
+        write: write
+      };
+      var contact = {};
+      var buffer = new Buffer(JSON.stringify({
+        method: 'ping',
+        id: 'someid',
+        params: [contact]
+      }));
+      renter.network = {
+        ping: sinon.stub().callsArgWith(1, null, {})
+      };
+      renter._handleWork(renter.workers.test, buffer);
+      expect(write.callCount).to.equal(1);
+      expect(JSON.parse(write.args[0][0].toString())).to.deep.equal({
+        id: 'someid',
+        result: [
+          null,
+          {}
+        ]
+      });
+      expect(renter.workers.test.ack.callCount).to.equal(1);
+    });
+
     it('will serialize/deserialize args with redirected method', function() {
       var renter = complex.createRenter(options);
       var pointer = {


### PR DESCRIPTION
**Description**

Adds a new `ping` command to check contacts in the network. And will record the `timeoutRate`, as similar to https://github.com/Storj/bridge/pull/323, to keep track of uptime of farmers, and when replication is necessary.

**As part of**
- https://github.com/Storj/bridge/pull/323