### PR TITLE
Fix issue with timeouts for error results

### DIFF
--- a/lib/landlord.js
+++ b/lib/landlord.js
@@ -404,27 +404,22 @@ Landlord.prototype._handleWorkResult = function(buffer) {
   var self = this;
   var data = JSON.parse(buffer.toString());
 
-  // If this response already timed out do nothing
   if (!self._pendingJobs[data.id]) {
-    return this._logger.warn('job %s completed late', data.id);
-  }
-
-  // If we got error back, then send a error code
-  if (data.error) {
-    self._logger.warn('error returned from work result on job %s', data.id);
-    self._logger.debug('error result: %j', data);
-    return self._pendingJobs[data.id].res.send(
+    this._logger.warn('job %s completed late after it timed out',
+                      data.id);
+  } else if (data.error) {
+    self._logger.warn('error returned from work result on job %s, reason: %j',
+                      data.id, data);
+    self._pendingJobs[data.id].res.send(
       new restify.errors.InternalServerError(data.error.message)
     );
+  } else {
+    self._logger.debug('job %s completed successfully, result: %j',
+                       data.id, data);
+    self._pendingJobs[data.id].res.send(data);
+
+    self._recordSuccessTime(self._pendingJobs[data.id]);
   }
-
-  // Otherwise forward the result and delete the reference
-  self._logger.info('job %s completed successfully', data.id);
-  self._logger.debug('job result: %j', data);
-  self._pendingJobs[data.id].res.send(data);
-
-  // Keep track of response times
-  self._recordSuccessTime(self._pendingJobs[data.id]);
 
   delete self._pendingJobs[data.id];
 };

--- a/test/landlord.unit.js
+++ b/test/landlord.unit.js
@@ -818,7 +818,7 @@ describe('Landlord', function() {
       };
       landlord._handleWorkResult(buffer);
       expect(landlord._logger.warn.callCount).to.equal(1);
-      expect(landlord._logger.debug.callCount).to.equal(1);
+      expect(landlord._pendingJobs.someid).to.equal(undefined);
       expect(send.callCount).to.equal(1);
       expect(send.args[0][0]).to.be.instanceOf(Error);
       expect(send.args[0][0].message).to.equal('rabbits are afk');
@@ -846,7 +846,6 @@ describe('Landlord', function() {
       };
       landlord._pendingJobs.someid = job;
       landlord._handleWorkResult(buffer);
-      expect(landlord._logger.info.callCount).to.equal(1);
       expect(landlord._logger.debug.callCount).to.equal(1);
       expect(send.callCount).to.equal(1);
       expect(landlord._pendingJobs.someid).to.equal(undefined);


### PR DESCRIPTION
The setTimeout callback at lib/landlord.js#L268 checks `self._pendingJobs[req.body.id]` to
determine if the job was completed, however that is never removed from `_pendingJobs`
when there is an error because it's deleted at lib/landlord.js#L429 after the
`return` at lib/landlord.js#L416 in `_handleWorkResult`.

Closes https://github.com/Storj/bridge/issues/413