### PR TITLE
bugfix mirror creation

### DIFF
--- a/lib/landlord.js
+++ b/lib/landlord.js
@@ -325,7 +325,7 @@ Landlord.prototype._getKeyFromRpcMessage = function(rpc) {
     case 'getStorageOffer':
       return rpc.params[0].data_hash; // Key based on the data hash
     case 'getMirrorNodes':
-      return rpc.params[0].hash; // Key based on the data hash
+      return rpc.params[0][0].hash; // Key based on the data hash
     default:
       return crypto.randomBytes(1).toString('hex'); // Select a random exchange
   }

--- a/test/landlord.unit.js
+++ b/test/landlord.unit.js
@@ -580,7 +580,7 @@ describe('Landlord', function() {
     it('should use the hash of pointer', function() {
       expect(Landlord.prototype._getKeyFromRpcMessage({
         method: 'getMirrorNodes',
-        params: [{ hash: 'datahash' }]
+        params: [[{ hash: 'datahash' }]]
       })).to.equal('datahash');
     });
 


### PR DESCRIPTION
```
Unable to mirror to farmer { shardHash: '7c9b04f04dd0775d3dd35d48c1deae2fedf03007',
contact: { [...] },
contract: { [...] },
reason: First argument must be a string, Buffer, ArrayBuffer, Array, or array-like object.
```

The bridge can't create mirrors at the moment because I did a mistake. An array of pointer is passed into getMirrorNodes. This pull request should fix my mistake.

You can see the array object here: https://github.com/Storj/complex/blob/8a5f8f7a2389f2828ea6c9c2041ee1e4471e9466/test/client.unit.js#L479