### PR TITLE
Fix contract renewal rpc implementation to work with sip4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,11 @@ jsdoc
 # Ignore browser build, but leave the directory
 dist/**
 !dist/.gitkeep
+
+# Ignore jetbrains .idea directory
+.idea/*
+
+# Ignore vim dotfiles
+*.swp
+*.swo
+*.swn

--- a/lib/client.js
+++ b/lib/client.js
@@ -79,6 +79,9 @@ Client.prototype._send = function(method, args, callback) {
 Client.prototype._deserializeResponseArguments = function(method, args) {
   /* jshint maxcomplexity:false */
   switch (method) {
+    case 'renewContract':
+      args[1] = storj.Contract(args[1]);
+      break;
     case 'getStorageOffer':
       args[1] = storj.Contact(args[1]);
       args[2] = storj.Contract.fromObject(args[2]);
@@ -114,6 +117,9 @@ Client.prototype._serializeRequestArguments = function(method, args) {
       args[0] = args[0].toObject();
       break;
     case 'renewContract':
+      args[0] = args[0].toObject();
+      args[1] = args[1].toObject();
+      break;
     case 'publishContract':
       args[1] = args[1].toObject();
       break;

--- a/lib/client.js
+++ b/lib/client.js
@@ -117,9 +117,6 @@ Client.prototype._serializeRequestArguments = function(method, args) {
       args[0] = args[0].toObject();
       break;
     case 'renewContract':
-      args[0] = args[0].toObject();
-      args[1] = args[1].toObject();
-      break;
     case 'publishContract':
       args[1] = args[1].toObject();
       break;

--- a/lib/client.js
+++ b/lib/client.js
@@ -110,10 +110,10 @@ Client.prototype._deserializeResponseArguments = function(method, args) {
 Client.prototype._serializeRequestArguments = function(method, args) {
   /* jshint maxcomplexity:false */
   switch (method) {
-    case 'renewContract':
     case 'getStorageOffer':
       args[0] = args[0].toObject();
       break;
+    case 'renewContract':
     case 'publishContract':
       args[1] = args[1].toObject();
       break;

--- a/lib/client.js
+++ b/lib/client.js
@@ -203,10 +203,10 @@ Client.prototype.ping = function(contact, callback) {
 /**
  * @see http://storj.github.io/core/RenterInterface.html
  */
-Client.prototype.renewContract = function(contract, contact, callback) {
+Client.prototype.renewContract = function(contact, contract, callback) {
   assert(contract instanceof storj.Contract, 'Invalid contact supplied');
   assert(contact instanceof storj.Contact, 'Invalid contract supplied');
-  this._send('renewContract', [contract, contact], callback);
+  this._send('renewContract', [contact, contract], callback);
 };
 
 Client.prototype.publishContract = function(contacts, contract, callback) {

--- a/lib/renter.js
+++ b/lib/renter.js
@@ -61,6 +61,7 @@ Renter.SAFE_LANDLORD_METHODS = [
   'getStorageOffer',
   'getStorageProof',
   'publishContract',
+  'renewContract',
   'ping'
 ];
 
@@ -424,6 +425,10 @@ Renter.prototype._deserializeArguments = function(method, args) {
       args[2] = typeof args[1] === 'function' ? args[1] : args[2];
       args[1] = Array.isArray(args[1]) ? args[1] : [];
       break;
+    case 'renewContract':
+      args[0] = storj.Contact(args[0]);
+      args[1] = storj.Contract.fromObject(args[1]);
+      break;
     default:
       // noop
   }
@@ -522,14 +527,25 @@ Renter.prototype._renewContract = function(contact, contract, callback) {
   });
 };
 
-Renter.prototype._renewContractMessage = function(contract, updatedContract) {
+Renter.prototype._getSigningKey = function (contract) {
+  if (!!contract.get('renter_hd_key') &&
+      !!contract.get('renter_hd_index')) {
+    return this.keyPair.getPrivateKey();
+  }
+
   assert(this.migrationKeyPair, 'migration private key is expected');
+  return this.migrationKeyPair.getPrivateKey();
+};
+
+Renter.prototype._renewContractMessage = function(contract, updatedContract) {
+  const signingKey = this._getSigningKey(contract);
+
   var msg = new kad.Message({
     method: 'RENEW',
     params: {
       renter_id: contract.get('renter_id'),
       renter_signature: updatedContract.signExternal(
-        this.migrationKeyPair.getPrivateKey()
+        signingKey
       ),
       contract: updatedContract.toObject(),
       contact: this.network.contact

--- a/test/client.unit.js
+++ b/test/client.unit.js
@@ -269,9 +269,10 @@ describe('Client', function() {
         address: '127.0.0.1',
         port: 3030
       });
-      var args = [contract, farmer];
+      var args = [farmer, contract];
       var result = client._serializeRequestArguments(method, args);
       expect(result).to.deep.equal([
+        farmer,
         {
           audit_count: 10,
           data_hash: null,
@@ -288,8 +289,7 @@ describe('Client', function() {
           store_begin: 2000000000,
           store_end: 3000000000,
           version: 0
-        },
-        farmer
+        }
       ]);
     });
 
@@ -573,12 +573,12 @@ describe('Client', function() {
         address: '127.0.0.1',
         port: 3030
       });
-      client.renewContract(contract, farmer, function() {
+      client.renewContract(farmer, contract, function() {
         expect(client._send.callCount).to.equal(1);
         expect(client._send.args[0][0]).to.equal('renewContract');
         expect(client._send.args[0][1]).to.deep.equal([
-          contract,
-          farmer
+          farmer,
+          contract
         ]);
         done();
       });


### PR DESCRIPTION
This should still be backwards compatible to pre-[sip4](https://github.com/Storj/sips/blob/master/sip-0004.md) and therefore still usable to migrate contract keys. If there is no `renter_hd_key` or `renter_hd_index` in the old contract, the `migrationKey` is used.