### PR TITLE
queueing publishContract and ping on worker queue close to nodeID

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ addons:
       - clang
 node_js:
   - "6.9.1"
+  - "8"
 before_install:
   - export CXX="g++-4.8" CC="gcc-4.8"
 after_script:

--- a/lib/landlord.js
+++ b/lib/landlord.js
@@ -334,12 +334,15 @@ Landlord.prototype._getKeyFromRpcMessage = function(rpc) {
     case 'getConsignmentPointer':
     case 'getRetrievalPointer':
     case 'renewContract':
+    case 'ping':
     case 'getStorageProof':
       return rpc.params[0].nodeID; // Key based on the target farmer
     case 'getStorageOffer':
       return rpc.params[0].data_hash; // Key based on the data hash
     case 'getMirrorNodes':
-      return rpc.params[0][0].hash; // Key based on the data hash
+      return rpc.params[1][0].nodeID; // Key based on the destination pointer
+    case 'publishContract':
+      return rpc.params[0][0]._id; // Key based on the first farmer
     default:
       return crypto.randomBytes(1).toString('hex'); // Select a random exchange
   }

--- a/test/client.unit.js
+++ b/test/client.unit.js
@@ -293,6 +293,38 @@ describe('Client', function() {
       ]);
     });
 
+    it('publishContract', function() {
+      var client = complex.createClient();
+      var method = 'publishContract';
+      var contract = new storj.Contract();
+      var farmer = storj.Contact({
+        address: '127.0.0.1',
+        port: 3030
+      });
+      var args = [farmer, contract];
+      var result = client._serializeRequestArguments(method, args);
+      expect(result).to.deep.equal([
+        farmer,
+        {
+          audit_count: 10,
+          data_hash: null,
+          data_size: 1234,
+          farmer_id: null,
+          farmer_signature: null,
+          payment_destination: null,
+          payment_download_price: 0,
+          payment_storage_price: 0,
+          renter_hd_index: false,
+          renter_hd_key: false,
+          renter_id: null,
+          renter_signature: null,
+          store_begin: 2000000000,
+          store_end: 3000000000,
+          version: 0
+        }
+      ]);
+    });
+
     it('getStorageProof', function() {
       var client = complex.createClient();
       var method = 'getStorageProof';
@@ -431,8 +463,29 @@ describe('Client', function() {
     it('getMirrorNodes', function() {
       var client = complex.createClient();
       var method = 'getMirrorNodes';
-      var args = [];
-      client._serializeRequestArguments(method, args);
+      var farmer = new storj.Contact({
+        address: '127.0.0.1',
+        port: 3030
+      });
+      var args = [
+        farmer
+      ];
+      var result = client._serializeRequestArguments(method, args);
+      expect(result).to.equal(args);
+    });
+
+    it('ping', function() {
+      var client = complex.createClient();
+      var method = 'ping';
+      var farmer = new storj.Contact({
+        address: '127.0.0.1',
+        port: 3030
+      });
+      var args = [
+        farmer
+      ];
+      var result = client._serializeRequestArguments(method, args);
+      expect(result).to.equal(args);
     });
   });
 
@@ -578,6 +631,33 @@ describe('Client', function() {
         expect(client._send.args[0][0]).to.equal('renewContract');
         expect(client._send.args[0][1]).to.deep.equal([
           farmer,
+          contract
+        ]);
+        done();
+      });
+    });
+
+  });
+
+  describe('#publishContract', function() {
+
+    it('should call send with corrent params', function(done) {
+      var client = complex.createClient();
+      client._send = sinon.stub().callsArg(2);
+      var contract = storj.Contract({});
+      var farmer1 = storj.Contact({
+        address: '127.0.0.1',
+        port: 3030
+      });
+      var farmer2 = storj.Contact({
+        address: '127.0.0.1',
+        port: 3030
+      });
+      client.publishContract([farmer1, farmer2], contract, function() {
+        expect(client._send.callCount).to.equal(1);
+        expect(client._send.args[0][0]).to.equal('publishContract');
+        expect(client._send.args[0][1]).to.deep.equal([
+          [farmer1, farmer2],
           contract
         ]);
         done();

--- a/test/landlord.unit.js
+++ b/test/landlord.unit.js
@@ -572,21 +572,56 @@ describe('Landlord', function() {
 
   describe('#_getKeyFromRpcMessage', function() {
 
-    it('should use the nodeID of farmer', function() {
+    it('getConsignmentPointer should use the nodeID of farmer', function() {
+      expect(Landlord.prototype._getKeyFromRpcMessage({
+        method: 'getConsignmentPointer',
+        params: [{ nodeID: 'nodeid' }]
+      })).to.equal('nodeid');
+    });
+
+    it('getRetrievalPointer should use the nodeID of farmer', function() {
+      expect(Landlord.prototype._getKeyFromRpcMessage({
+        method: 'getRetrievalPointer',
+        params: [{ nodeID: 'nodeid' }]
+      })).to.equal('nodeid');
+    });
+
+    it('renewContract should use the nodeID of farmer', function() {
+      expect(Landlord.prototype._getKeyFromRpcMessage({
+        method: 'renewContract',
+        params: [{ nodeID: 'nodeid' }]
+      })).to.equal('nodeid');
+    });
+
+    it('publishContract should use the nodeID of farmer', function() {
+      expect(Landlord.prototype._getKeyFromRpcMessage({
+        method: 'publishContract',
+        params: [[{ nodeID: 'nodeid1' }, { nodeID: 'nodeid2' }]]
+      })).to.equal('nodeid1');
+    });
+
+    it('getStorageProof should use the nodeID of farmer', function() {
       expect(Landlord.prototype._getKeyFromRpcMessage({
         method: 'getStorageProof',
         params: [{ nodeID: 'nodeid' }]
       })).to.equal('nodeid');
     });
 
-    it('should use the data hash of contract', function() {
+    it('ping should use the nodeID of farmer', function() {
+      expect(Landlord.prototype._getKeyFromRpcMessage({
+        method: 'ping',
+        params: [{ nodeID: 'nodeid' }]
+      })).to.equal('nodeid');
+    });
+
+    it('getStorageOffer should use the data hash of contract', function() {
       expect(Landlord.prototype._getKeyFromRpcMessage({
         method: 'getStorageOffer',
         params: [{ data_hash: 'datahash' }]
       })).to.equal('datahash');
     });
 
-    it('should use the hash of pointer', function() {
+    it('getMirrorNodes should use the hash of pointer', function() {
       expect(Landlord.prototype._getKeyFromRpcMessage({
         method: 'getMirrorNodes',
         params: [[{ hash: 'datahash' }]]

--- a/test/landlord.unit.js
+++ b/test/landlord.unit.js
@@ -596,7 +596,7 @@ describe('Landlord', function() {
     it('publishContract should use the nodeID of farmer', function() {
       expect(Landlord.prototype._getKeyFromRpcMessage({
         method: 'publishContract',
-        params: [[{ nodeID: 'nodeid1' }, { nodeID: 'nodeid2' }]]
+        params: [[{ _id: 'nodeid1' }, { _id: 'nodeid2' }]]
       })).to.equal('nodeid1');
     });
 
@@ -624,8 +624,8 @@ describe('Landlord', function() {
     it('getMirrorNodes should use the hash of pointer', function() {
       expect(Landlord.prototype._getKeyFromRpcMessage({
         method: 'getMirrorNodes',
-        params: [[{ hash: 'datahash' }]]
-      })).to.equal('datahash');
+        params: [[{ hash: 'datahash' }], [{ nodeID: 'nodeid' }]]
+      })).to.equal('nodeid');
     });
 
     it('should be random', function() {


### PR DESCRIPTION
I would expect alloc and ping message comming from renterIDs close to my nodeID. At the moment all renterIDs try to comunicate with me. In return I as farmer will have to spam the bridge with PUBLISH messages because sooner or later my contact list is full with to many renterIDs.

This pull request will fix it.

Mirror has this problem as well but I don't want to change to much at the same time. Mirror will use the shard hash to queue the job. That was fine the early days because the shard hash was close to all mirror farmer. We removed that relationship and would have to use the first destination now. However I would need a test environment to try this. I don't want to risk it on the main net. Thats why I havent included it in this pull request.

I noticed that contractRenewal has duplicate code blocks. It has a serializer and desiralizer but is bypassing them by sending a RAW message itself. If we are going to keep complex for a few more days I could try to clean up the unused code. Would still look ugly but not as confusing as the current situation.